### PR TITLE
Remove automerge

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,7 @@ provider:
   win: azure
 conda_forge_output_validation: true
 bot:
-  automerge: true
+  automerge: false
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
I'm firmly in the camp that it is better to not publish broken packages and that it is also easier to fix an automatically created PR than to create a new PR to fix the dependencies, and if you want to be 100% correct, to also open a PR on [`conda-forge-repodata-patches-feedstock`](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock).

I will endeavour to update the deps in a (*relatively*) timely fashion, or accept PRs to do the same.